### PR TITLE
feat: Send logs as JSON file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Example Slack message can be found below:
 - Status: Status.SUCCESS
 - Device Port: /dev/ttyACM0
 - Total Elapsed Time: 4.041985750198364
-(as test_result.json)):
+(as test_result.json):
 [
     {
         "command": "SOME_COMMAND",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Example Slack message can be found below:
 - Status: Status.SUCCESS
 - Device Port: /dev/ttyACM0
 - Total Elapsed Time: 4.041985750198364
-"""
+(as test_result.json)):
 [
     {
         "command": "SOME_COMMAND",
@@ -25,7 +25,6 @@ Example Slack message can be found below:
     },
     (...)
 ]
-"""
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -28,20 +28,18 @@ Example Slack message can be found below:
 """
 ```
 
-## Configuration
-Create `~/.tinycell_coordinator/.env` file.
-`.env` file must iclude following variables:
-```
-SLACK_BOT_TOKEN
-SLACK_REPORT_CHANNEL
-```
-
-
 ## Usage
 Before calling the `run.py`, make sure that you've installed modules in `requirements.txt` file.
+Create a .env file as described in the next section.
 ```bash
 ~$ python run.py [-h] -p PORT [PORT ...] -t TEST [TEST ...]
 ```
+
+### Environmental Variables
+Environment file must be kept on `~/.tinycell_test-coordinator/.env` location -- even if you don't use test-coordinator program. It is designed this way to have integration with each other. In this environment secrets file, you have to set two variables to work with Slack.
+- `SLACK_BOT_TOKEN`: Bot User OAuth Token which can be found on api.slack.com.
+- `SLACK_REPORT_CHANNEL_ID`: Slack channel ID where you want to send the logs.
+
 ### Status Types
 These status messages will be returned by the program to Slack channel.
 - `Status.SUCCESS`: All tests passed.
@@ -49,11 +47,6 @@ These status messages will be returned by the program to Slack channel.
 - `Status.TIMEOUT`: At least one test timed out.
 - `WATCHDOG_TIMEOUT`: Watchdog stopped the program.
 - `TERMINATE_REQUEST`: Program was terminated by coordinator (SIGUSR1).
-
-### Environmental Variables
-Environment file should be kept on `~/.tinycell_test-coordinator/.env` location -- even if you don't use test-coordinator program. It is designed this way to have integration with each other. In this environment secrets file, you have to set two variables to work with Slack.
-- `SLACK_BOT_TOKEN`: Bot User OAuth Token which can be found on api.slack.com.
-- `SLACK_REPORT_CHANNEL`: Slack channel where you want to send the logs including "#" character.
 
 ## Architecture
 The architecture relies on a test manager class inherited from the state manager used in Tinycell SDK. The problem we did overcome is the implementation of `execute_current_step()` method which was calling a pointer with function parameters given. The inheritence allows us to re-implement that method with desired execution function. In TesterManager class, we send the given functions and their parameters into Tinycell device with using Pyboard tool.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # tinycell_test-process
-Repo for testing tinycell devices over a linux OS. This program opens a serial connection between your host machine and Tinycell, and sends commmands using state manager architecture. It does not output anything to standart output, but logs the current test results on `.log/` and sends a message to given Slack channel.
+Repo for testing tinycell devices over a linux OS. This program opens a serial connection between your host machine and Tinycell, and sends commmands using state manager architecture. It does not output anything to standart output, but logs the current test results on `reports/` and sends a message to given Slack channel.
 
 Example Slack message can be found below:
 ```md

--- a/testprocess/core/helpers/config.py
+++ b/testprocess/core/helpers/config.py
@@ -2,8 +2,7 @@
 import os
 from dotenv import load_dotenv
 
-# TEMP_PATH = os.path.expanduser("~") + "/.tinycell_test-coordinator"
-TEMP_PATH = "."
+TEMP_PATH = os.path.expanduser("~") + "/.tinycell_test-coordinator"
 ENVIRONMENT_PATH = f"{TEMP_PATH}/.env"
 TESTS_DIR = "tests"
 

--- a/testprocess/core/helpers/config.py
+++ b/testprocess/core/helpers/config.py
@@ -2,7 +2,8 @@
 import os
 from dotenv import load_dotenv
 
-TEMP_PATH = os.path.expanduser("~") + "/.tinycell_test-coordinator"
+# TEMP_PATH = os.path.expanduser("~") + "/.tinycell_test-coordinator"
+TEMP_PATH = "."
 ENVIRONMENT_PATH = f"{TEMP_PATH}/.env"
 TESTS_DIR = "tests"
 
@@ -14,5 +15,5 @@ if not os.path.exists(REPORT_PATH):
 load_dotenv(ENVIRONMENT_PATH)
 
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
-SLACK_REPORT_CHANNEL = os.environ.get("SLACK_REPORT_CHANNEL")
+SLACK_REPORT_CHANNEL_ID = os.environ.get("SLACK_REPORT_CHANNEL_ID")
 SLACK_COMMAND_CHANNEL = os.environ.get("SLACK_COMMAND_CHANNEL")

--- a/testprocess/core/slackbot.py
+++ b/testprocess/core/slackbot.py
@@ -5,13 +5,15 @@ This modules handles the connection and sending messages to Slack.
 import json
 from slack_bolt import App
 
+
 class SlackBot:
     """This class is used to send messages to slack."""
 
-    def __init__(self, bot_token: str, channel: str) -> None:
+    def __init__(self, bot_token: str, channel_id: str) -> None:
         """This function initializes the SlackBot class."""
         self.app = App(token=bot_token)
-        self.channel = channel
+        # Note that this is the channel ID but not its name.
+        self.channel = channel_id
 
     def send_results(self, test_result: dict) -> None:
         """This function sends a message to the channel."""
@@ -22,14 +24,15 @@ class SlackBot:
             f'- Status: *{test_result.get("status_of_test")}*\n'
             f'- Device Port: {test_result.get("device_port")}\n'
             f'- Total Elapsed Time: {test_result.get("total_elapsed_time")}\n\n'
-            f"```\n"
-            f"{json_logs}\n"
-            f"```\n"
         )
+
         try:
             while True:
-                result = self.app.client.chat_postMessage(
-                    channel=self.channel, text=message
+                result = self.app.client.files_upload_v2(
+                    channel=self.channel,
+                    initial_comment=message,
+                    content=json_logs,
+                    filename="test_results.json",
                 )
 
                 if result.get("ok"):

--- a/testprocess/run.py
+++ b/testprocess/run.py
@@ -8,7 +8,7 @@ import json
 from importlib import import_module
 from dotenv import load_dotenv
 
-from core.helpers.config import SLACK_BOT_TOKEN, SLACK_REPORT_CHANNEL, TESTS_DIR
+from core.helpers.config import SLACK_BOT_TOKEN, SLACK_REPORT_CHANNEL_ID, TESTS_DIR
 from core.slackbot import SlackBot
 
 
@@ -74,5 +74,5 @@ if __name__ == "__main__":
     # Send the result to Slack.
     load_dotenv()
 
-    slack_bot = SlackBot(SLACK_BOT_TOKEN, SLACK_REPORT_CHANNEL)
+    slack_bot = SlackBot(SLACK_BOT_TOKEN, SLACK_REPORT_CHANNEL_ID)
     slack_bot.send_results(test_result)


### PR DESCRIPTION
With this PR,
- The logs are being sent as a JSON file instead of big-long code snippet messages.
- Due to the limitation of Slack Bolt API, the ID is needed instead of channel name.
- README updated according to changes.
- Environmental variable `SLACK_REPORT_CHANNEL` changed to `SLACK_REPORT_CHANNEL_ID` to indicate that it is ID, not the name.