### PR TITLE
feat: Add support for collecting exception logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These status messages will be returned by the program to Slack channel.
 - `Status.TIMEOUT`: At least one test timed out.
 - `WATCHDOG_TIMEOUT`: Watchdog stopped the program.
 - `TERMINATE_REQUEST`: Program was terminated by coordinator (SIGUSR1).
+- `MP_EXCEPTON`: A MicroPython exception occured.
 
 ### Environmental Variables
 Environment file should be kept on `~/.tinycell_test-coordinator/.env` location -- even if you don't use test-coordinator program. It is designed this way to have integration with each other. In this environment secrets file, you have to set two variables to work with Slack.

--- a/testprocess/core/testermanager.py
+++ b/testprocess/core/testermanager.py
@@ -95,14 +95,22 @@ class TesterManager(StateManager):
 
         # If WatchdogTimeout is raised, append the status and finish test.
         except WatchdogTimeout:
+            self._add_log("WATCHDOG_TIMEOUT", "WATCHDOG_TIMEOUT", -1)
             logs_as_dict = self._export_logs_as_dict()
             logs_as_dict["status_of_test"] = "WATCHDOG_TIMEOUT"
             return logs_as_dict
 
         # If TerminateRequest came from coordinator, append the status and finish test.
         except TerminateRequest:
+            self._add_log("TERMINATE_REQUEST", "TERMINATE_REQUEST", -1)
             logs_as_dict = self._export_logs_as_dict()
             logs_as_dict["status_of_test"] = "TERMINATE_REQUEST"
+            return logs_as_dict
+
+        except Exception as error_message:
+            self._add_log("MicroPython Exception", str(error_message), -1)
+            logs_as_dict = self._export_logs_as_dict()
+            logs_as_dict["status_of_test"] = "MP_EXCEPTION"
             return logs_as_dict
 
         # Return the logs.


### PR DESCRIPTION
Withing this PR,
* The process will save the watchdog and terminate requests into logs, which allows us to see them in file-based and Slack-based log JSON files.
* During my testing process, it is shown that (Micro)Python exception saving is required. Now, it is supported and can be seen on both Slack and file-based log files. Also, "MP_EXCEPTION" test status is added.