### PR TITLE
fix: Solve minor problems on connecting to coordinator

### DIFF
--- a/testprocess/core/loginfo.py
+++ b/testprocess/core/loginfo.py
@@ -1,5 +1,6 @@
 from core.helpers.status import Status
 
+
 class LogInfo:
     """This class stores the log information of the command."""
 
@@ -16,13 +17,13 @@ class LogInfo:
             "elapsed_time": self.elapsed_time,
         }
 
-    def get_status(self) -> bool:
+    def get_status(self) -> int:
         """It checks if any status returned Status.ERROR.
 
         Returns
         -------
-        bool
-            True if command succees, False otherwise.
+        int
+            Status response of the command.
         """
         for per_result in self.result:
             if f"'status': {Status.ERROR}" in per_result:

--- a/testprocess/core/slackbot.py
+++ b/testprocess/core/slackbot.py
@@ -27,9 +27,6 @@ class SlackBot:
             f'\t\t- Timeout: {test_result.get("status_counts").get("Status.TIMEOUT")}\n'
             f'- *Device Port*: {test_result.get("device_port")}\n'
             f'- *Total Elapsed Time*: {test_result.get("total_elapsed_time")}\n\n'
-            f'```\n'
-            f'{json_logs}\n'
-            f'```\n'
         )
 
         try:

--- a/testprocess/core/testermanager.py
+++ b/testprocess/core/testermanager.py
@@ -30,7 +30,8 @@ class TesterManager(StateManager):
     for the testing purposes which uses StateManager
     as its base class.
     """
-    TERMINATION_SIGNAL = signal.SIGUSR1
+
+    TERMINATION_SIGNAL = signal.SIGTERM
 
     def __init__(self, first_step, function_name=None) -> None:
         # User-defined attributes.
@@ -213,9 +214,7 @@ class TesterManager(StateManager):
         result_command_b = self.pyb.exec_("print(result)")
 
         # Extract information from the byte array.
-        result = self._extract_result(result_debug_b) + self._extract_result(
-            result_command_b
-        )
+        result = self._extract_result(result_debug_b) + self._extract_result(result_command_b)
         # Add this command to logs.
         log = self._add_log(command, result, elapsed_time)
 
@@ -296,7 +295,6 @@ class TesterManager(StateManager):
                 raise ValueError("Unknown status.")
 
         return status_counts
-
 
     def _watchdog_handler(self, signum: int, _):
         """It handles the watchdog timeout."""

--- a/testprocess/core/testermanager.py
+++ b/testprocess/core/testermanager.py
@@ -135,6 +135,23 @@ class TesterManager(StateManager):
 
         return Status.SUCCESS
 
+    def get_status_string(self) -> str:
+        """It returns the last status of the logs.
+
+        Returns
+        -------
+        string
+            A Status indicator string.
+        """
+        # Get status of test for more summarized information.
+        status_of_test = "Status.SUCCESS"
+        if self.logs[-1].get_status() == Status.ERROR:
+            status_of_test = "Status.ERROR"
+        elif self.logs[-1].get_status() == Status.TIMEOUT:
+            status_of_test = "Status.TIMEOUT"
+
+        return status_of_test
+
     ############################
     ##    INTERNAL METHODS    ##
     ############################
@@ -254,18 +271,11 @@ class TesterManager(StateManager):
         """
         logs_as_dict_list = [log.to_dict() for log in self.logs]
 
-        # Get status of test for more summarized information.
-        status_of_test = "Status.SUCCESS"
-        if self.check_any_problem() == Status.ERROR:
-            status_of_test = "Status.ERROR"
-        elif self.check_any_problem() == Status.TIMEOUT:
-            status_of_test = "Status.TIMEOUT"
-
         return {
             "test_name": self.function_name,
             "device_port": self.tinycell_port,
             "total_elapsed_time": self.total_elapsed_time,
-            "status_of_test": status_of_test,
+            "status_of_test": self.get_status_string(),
             "status_counts": self._get_status_counts(),
             "logs": logs_as_dict_list,
         }


### PR DESCRIPTION
Due to the previous merging processes, there may be some parts which has been forgotten or not changed. Within this PR,
- SIGUSR1 changed as SIGTERM, to have decent connection with `tinycell_test-coordinator`.
- Removed the code snippet logs before logs file sent.
- Changed relevant return type of the code snippet `LogInfo::get_status()`
- Changed the test status indicator to last command's status instead of any error/timeout.