### PR TITLE
fix: Solve the failing issue when inner State Manager used

### DIFF
--- a/testprocess/core/loginfo.py
+++ b/testprocess/core/loginfo.py
@@ -1,5 +1,6 @@
 from core.helpers.status import Status
 
+
 class LogInfo:
     """This class stores the log information of the command."""
 
@@ -16,13 +17,13 @@ class LogInfo:
             "elapsed_time": self.elapsed_time,
         }
 
-    def get_status(self) -> bool:
+    def get_status(self) -> int:
         """It checks if any status returned Status.ERROR.
 
         Returns
         -------
-        bool
-            True if command succees, False otherwise.
+        int
+            Status response of the command.
         """
         for per_result in self.result:
             if f"'status': {Status.ERROR}" in per_result:

--- a/testprocess/core/loginfo.py
+++ b/testprocess/core/loginfo.py
@@ -17,6 +17,18 @@ class LogInfo:
             "elapsed_time": self.elapsed_time,
         }
 
+    def get_last_log(self) -> list:
+        """It returns the last meaningful log list.
+
+        Returns
+        -------
+        list
+            Last meaningful log list.
+        """
+        for per_result in reversed(self.result):
+            if per_result:
+                return per_result
+
     def get_status(self) -> int:
         """It checks if any status returned Status.ERROR.
 
@@ -25,11 +37,12 @@ class LogInfo:
         int
             Status response of the command.
         """
-        for per_result in self.result:
-            if f"'status': {Status.ERROR}" in per_result:
+        last_log = self.get_last_log()
+        if last_log is not None:
+            if f"'status': {Status.ERROR}" in last_log:
                 return Status.ERROR
-
-            if f"'status': {Status.TIMEOUT}" in per_result:
+            elif f"'status': {Status.TIMEOUT}" in last_log:
                 return Status.TIMEOUT
-
-        return Status.SUCCESS
+            elif f"'status': {Status.SUCCESS}" in last_log:
+                return Status.SUCCESS
+        return Status.UNKNOWN

--- a/testprocess/core/slackbot.py
+++ b/testprocess/core/slackbot.py
@@ -27,9 +27,6 @@ class SlackBot:
             f'\t\t- Timeout: {test_result.get("status_counts").get("Status.TIMEOUT")}\n'
             f'- *Device Port*: {test_result.get("device_port")}\n'
             f'- *Total Elapsed Time*: {test_result.get("total_elapsed_time")}\n\n'
-            f'```\n'
-            f'{json_logs}\n'
-            f'```\n'
         )
 
         try:

--- a/testprocess/core/testermanager.py
+++ b/testprocess/core/testermanager.py
@@ -30,7 +30,8 @@ class TesterManager(StateManager):
     for the testing purposes which uses StateManager
     as its base class.
     """
-    TERMINATION_SIGNAL = signal.SIGUSR1
+
+    TERMINATION_SIGNAL = signal.SIGTERM
 
     def __init__(self, first_step, function_name=None) -> None:
         # User-defined attributes.
@@ -213,9 +214,7 @@ class TesterManager(StateManager):
         result_command_b = self.pyb.exec_("print(result)")
 
         # Extract information from the byte array.
-        result = self._extract_result(result_debug_b) + self._extract_result(
-            result_command_b
-        )
+        result = self._extract_result(result_debug_b) + self._extract_result(result_command_b)
         # Add this command to logs.
         log = self._add_log(command, result, elapsed_time)
 
@@ -296,7 +295,6 @@ class TesterManager(StateManager):
                 raise ValueError("Unknown status.")
 
         return status_counts
-
 
     def _watchdog_handler(self, signum: int, _):
         """It handles the watchdog timeout."""

--- a/testprocess/core/testermanager.py
+++ b/testprocess/core/testermanager.py
@@ -6,6 +6,7 @@ import os
 import time
 import json
 import signal
+import logging
 from datetime import datetime
 
 from core.helpers.config import REPORT_PATH
@@ -32,6 +33,7 @@ class TesterManager(StateManager):
     """
 
     TERMINATION_SIGNAL = signal.SIGTERM
+    logging.basicConfig(level=logging.INFO)
 
     def __init__(self, first_step, function_name=None) -> None:
         # User-defined attributes.
@@ -53,6 +55,7 @@ class TesterManager(StateManager):
         """It sets the port of the device."""
         self.tinycell_port = port
         self.pyb = Pyboard(self.tinycell_port)
+        logging.info("Port is set to %s.", self.tinycell_port)
 
     def run_the_test(self, timeout: int = None) -> list:
         """It runs all the steps on the
@@ -75,6 +78,7 @@ class TesterManager(StateManager):
             timeout = 300  # seconds
         self.wdg_timeout = timeout
         self.watchdog = Watchdog(timeout, self._watchdog_handler)
+        logging.info("Watchdog is set to %d seconds.", timeout)
 
         # Append SIGTERM handler.
         signal.signal(self.TERMINATION_SIGNAL, self._sudden_kill_handler)
@@ -83,19 +87,25 @@ class TesterManager(StateManager):
             self._start_repl()
             # Send the setup commands.
             self._prepare_setup()
+            logging.info("REPL started and setup commands are sent.")
 
             # Run the state manager.
             while True:
+                # Run the current step.
+                logging.info("Running step %s.", self.current.name)
                 result = self.run()
+                logging.info("Step %s is finished.", self.current.name)
                 if result["status"] != Status.ONGOING:
                     break
                 time.sleep(result["interval"])
 
             # Close the REPL.
             self._stop_repl()
+            logging.info("REPL is closed.")
 
         # If WatchdogTimeout is raised, append the status and finish test.
         except WatchdogTimeout:
+            logging.info("Watchdog timeout is raised.")
             self._add_log("WATCHDOG_TIMEOUT", "WATCHDOG_TIMEOUT", -1)
             logs_as_dict = self._export_logs_as_dict()
             logs_as_dict["status_of_test"] = "WATCHDOG_TIMEOUT"
@@ -103,12 +113,14 @@ class TesterManager(StateManager):
 
         # If TerminateRequest came from coordinator, append the status and finish test.
         except TerminateRequest:
+            logging.info("Terminate request is raised.")
             self._add_log("TERMINATE_REQUEST", "TERMINATE_REQUEST", -1)
             logs_as_dict = self._export_logs_as_dict()
             logs_as_dict["status_of_test"] = "TERMINATE_REQUEST"
             return logs_as_dict
 
         except Exception as error_message:
+            logging.info("MicroPython exception is raised: \n%s", error_message)
             self._add_log("MicroPython Exception", str(error_message), -1)
             logs_as_dict = self._export_logs_as_dict()
             logs_as_dict["status_of_test"] = "MP_EXCEPTION"
@@ -225,10 +237,12 @@ class TesterManager(StateManager):
             It includes the status, response and
             elapsed time of the command.
         """
+        logging.info("Sending command: %s.", command)
         start_execution_time = time.time()
         result_debug_b = self.pyb.exec_(f"result = {command}")
         elapsed_time = time.time() - start_execution_time
         result_command_b = self.pyb.exec_("print(result)")
+        logging.info("Command is resulted as: %s.", result_command_b.decode("utf-8")[:-2])
 
         # Extract information from the byte array.
         result = self._extract_result(result_debug_b) + self._extract_result(result_command_b)

--- a/testprocess/core/testermanager.py
+++ b/testprocess/core/testermanager.py
@@ -33,7 +33,7 @@ class TesterManager(StateManager):
     """
 
     TERMINATION_SIGNAL = signal.SIGTERM
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s --> %(levelname)-8s %(message)s")
 
     def __init__(self, first_step, function_name=None) -> None:
         # User-defined attributes.
@@ -127,6 +127,7 @@ class TesterManager(StateManager):
             return logs_as_dict
 
         # Return the logs.
+        logging.info("Test is finished. Exporting logs.")
         return self._export_logs_as_dict()
 
     def check_any_problem(self) -> int:
@@ -242,7 +243,7 @@ class TesterManager(StateManager):
         result_debug_b = self.pyb.exec_(f"result = {command}")
         elapsed_time = time.time() - start_execution_time
         result_command_b = self.pyb.exec_("print(result)")
-        logging.info("Command is resulted as: %s.", result_command_b.decode("utf-8")[:-2])
+        logging.info("Command is resulted as \t%s.", result_command_b.decode("utf-8")[:-2])
 
         # Extract information from the byte array.
         result = self._extract_result(result_debug_b) + self._extract_result(result_command_b)
@@ -315,8 +316,10 @@ class TesterManager(StateManager):
                 status_counts["Status.ERROR"] += 1
             elif log.get_status() == Status.TIMEOUT:
                 status_counts["Status.TIMEOUT"] += 1
+            elif log.get_status() == Status.UNKNOWN:
+                pass
             else:
-                raise ValueError("Unknown status.")
+                raise ValueError("Couldn't parse status.")
 
         return status_counts
 

--- a/testprocess/core/testermanager.py
+++ b/testprocess/core/testermanager.py
@@ -135,6 +135,23 @@ class TesterManager(StateManager):
 
         return Status.SUCCESS
 
+    def get_status_string(self) -> str:
+        """It returns the last status of the logs.
+
+        Returns
+        -------
+        string
+            A Status indicator string.
+        """
+        # Get status of test for more summarized information.
+        status_of_test = "Status.SUCCESS"
+        if self.logs[-1].get_status() == Status.ERROR:
+            status_of_test = "Status.ERROR"
+        elif self.logs[-1].get_status() == Status.TIMEOUT:
+            status_of_test = "Status.TIMEOUT"
+
+        return status_of_test
+
     ############################
     ##    INTERNAL METHODS    ##
     ############################
@@ -254,18 +271,11 @@ class TesterManager(StateManager):
         """
         logs_as_dict_list = [log.to_dict() for log in self.logs]
 
-        # Get status of test for more summarized information.
-        status_of_test = "Status.SUCCESS"
-        if self.check_any_problem() == Status.ERROR:
-            status_of_test = "Status.ERROR"
-        elif self.check_any_problem() == Status.TIMEOUT:
-            status_of_test = "Status.TIMEOUT"
-
         return {
             "test_name": self.function_name,
             "device_port": self.tinycell_port,
             "total_elapsed_time": self.total_elapsed_time,
-            "status_of_test": status_of_test,
+            "status_of_test": self.get_status_string(),
             "status_counts": self._get_status_counts(),
             "logs": logs_as_dict_list,
         }


### PR DESCRIPTION
Whenever tests includes an inner State Manager as a step, and even one of the steps of that inner state manager fails, the current test step totally accepted as failed. Within this PR,
- The problem is fixed by just searching for the last meaningful "result" status. In State Managers, it is the last step's result.
- On the researching phase, the logging is added for further investment.